### PR TITLE
Fix trailing whitespace formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ pip install findatapy
 FinancePy is an optional dependency for finmarketpy for option pricing. It is recommended
 to install it separately from PyPI after installing finmarketpy, and without dependencies
 otherwise it can cause clashes with other libraries (because of its strict version
-dependencies on libraries like llvmlite, which in practice can be relaxed). 
+dependencies on libraries like llvmlite, which in practice can be relaxed).
 The API changes a lot so it recommended to install the specific version listed below.
 
 ```

--- a/finmarketpy_examples/backtest_example.py
+++ b/finmarketpy_examples/backtest_example.py
@@ -16,7 +16,7 @@ __author__ = 'saeedamen'  # Saeed Amen
 #
 
 """
-Gives several examples of backtesting simple trading strategies, using 
+Gives several examples of backtesting simple trading strategies, using
 Backtest (a lower level class)
 """
 

--- a/finmarketpy_examples/fx_vol_surface_interpolation_examples.py
+++ b/finmarketpy_examples/fx_vol_surface_interpolation_examples.py
@@ -16,12 +16,12 @@ __author__ = 'saeedamen'  # Saeed Amen
 #
 
 """
-Shows how to use finmarketpy to process FX vol surfaces which have been 
+Shows how to use finmarketpy to process FX vol surfaces which have been
 interpolated (uses FinancePy underneath).
 
-Note, you will need to have a Bloomberg terminal (with blpapi Python library) 
-to download the FX market data in order to plot these vol surface (FX spot, 
-FX forwards, FX implied_vol volatility 
+Note, you will need to have a Bloomberg terminal (with blpapi Python library)
+to download the FX market data in order to plot these vol surface (FX spot,
+FX forwards, FX implied_vol volatility
 quotes and deposits)
 """
 

--- a/finmarketpy_examples/vol_stats_examples.py
+++ b/finmarketpy_examples/vol_stats_examples.py
@@ -16,11 +16,11 @@ __author__ = 'saeedamen'  # Saeed Amen
 #
 
 """
-Here we show how to use VolStats to calculate various volatility metrics 
+Here we show how to use VolStats to calculate various volatility metrics
 (like realized volatility, volatility risk premium and the implied volatility addons)
 
-Note, you will need to have a Bloomberg terminal (with blpapi Python library) 
-to download the FX market data in order to run most of these examples (FX spot, 
+Note, you will need to have a Bloomberg terminal (with blpapi Python library)
+to download the FX market data in order to run most of these examples (FX spot,
 FX forwards, FX implied_vol volatility quotes and deposits)
 """
 


### PR DESCRIPTION
## Summary
- Run `make fmt` (pre-commit hooks) to fix trailing whitespace across the codebase
- Fixes trailing whitespace in `README.md`, `backtest_example.py`, `vol_stats_examples.py`, and `fx_vol_surface_interpolation_examples.py`
- All pre-commit hooks now pass cleanly

Closes #57

## Test plan
- [ ] Verify `make fmt` passes with no changes
- [ ] Confirm no functional changes — only trailing whitespace removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)